### PR TITLE
CI: desktop builds stable on mac + no multi-lockfile

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -7,23 +7,33 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix: { os: [windows-latest, macos-latest] }
     runs-on: ${{ matrix.os }}
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: "false"   # do not attempt mac codesigning
+      DEBUG: "electron-builder"              # verbose logs for troubleshooting
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
       - uses: pnpm/action-setup@v4
         with: { version: 9, run_install: false }
+
       - name: Install web deps
         run: pnpm -C web install
+
       - name: Build web (Next static export)
         run: pnpm -C web build
+
       - name: Install desktop deps
         run: pnpm -C desktop install
+
       - name: Build desktop artifacts
         run: pnpm -C desktop dist
+
       - name: Upload artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: desktop-${{ matrix.os }}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -25,7 +25,13 @@
     "files": ["main.js","package.json"],
     "extraResources": [{ "from": "../web/out", "to": "app-web" }],
     "directories": { "output": "dist" },
-    "mac": { "target": ["dmg"], "category": "public.app-category.games" },
-    "win": { "target": ["nsis"] }
+    "mac": {
+      "target": ["dmg"],
+      "category": "public.app-category.games",
+      "identity": null
+    },
+    "win": {
+      "target": ["nsis"]
+    }
   }
 }


### PR DESCRIPTION
Disable codesign auto-discovery; remove root lockfiles; fail-fast=false; DEBUG=e- builder.