### PR TITLE
Desktop build fix: electron in devDependencies

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,11 +11,10 @@
     "pack": "pnpm run build:web && electron-builder --dir",
     "dist": "pnpm run build:web && electron-builder"
   },
-  "dependencies": {
-    "electron": "^30.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "concurrently": "^9.0.0",
+    "electron": "^30.0.0",
     "electron-builder": "^24.13.3",
     "wait-on": "^7.2.0"
   },
@@ -32,6 +31,7 @@
     },
     "win": {
       "target": ["nsis"]
-    }
+    },
+    "publish": "never"
   }
 }


### PR DESCRIPTION
Moves electron to devDependencies and sets publish=never so CI builds artifacts without publishing.